### PR TITLE
Performance optimization

### DIFF
--- a/src/main/java/com/pau101/fairylights/server/ServerEventHandler.java
+++ b/src/main/java/com/pau101/fairylights/server/ServerEventHandler.java
@@ -74,7 +74,7 @@ public final class ServerEventHandler {
 	@SubscribeEvent
 	public void onGetCollisionBoxes(GetCollisionBoxesEvent event) {
 		Entity entity = event.getEntity();
-		if (entity != null && entity instanceof EntityPlayer) {
+		if (entity instanceof EntityPlayer) {
 			AxisAlignedBB bounds = event.getAabb();
 			List<EntityLadder> ladders = event.getWorld().getEntitiesWithinAABB(EntityLadder.class, bounds.grow(1));
 			List<AxisAlignedBB> boxes = event.getCollisionBoxesList();

--- a/src/main/java/com/pau101/fairylights/server/ServerEventHandler.java
+++ b/src/main/java/com/pau101/fairylights/server/ServerEventHandler.java
@@ -74,7 +74,7 @@ public final class ServerEventHandler {
 	@SubscribeEvent
 	public void onGetCollisionBoxes(GetCollisionBoxesEvent event) {
 		Entity entity = event.getEntity();
-		if (entity != null) {
+		if (entity != null && entity instanceof EntityPlayer) {
 			AxisAlignedBB bounds = event.getAabb();
 			List<EntityLadder> ladders = event.getWorld().getEntitiesWithinAABB(EntityLadder.class, bounds.grow(1));
 			List<AxisAlignedBB> boxes = event.getCollisionBoxesList();


### PR DESCRIPTION
While profiling my server I found that this mod was a pretty big performance hit.
Turns out it was checking the hitboxes of all living entities in my world, which is pretty heavy code that takes a while to run (and do sheep, or bats, or etc. really need to be able to use the stepladder?).

Small change, huge difference, the method now takes as long as you'd expect it to with greatly improved performance.