### PR TITLE
Fixed a bug causing crashes

### DIFF
--- a/src/main/java/me/paulf/fairylights/util/Mth.java
+++ b/src/main/java/me/paulf/fairylights/util/Mth.java
@@ -96,7 +96,7 @@ public final class Mth {
 
     public static int log2(int n) {
         if (n <= 0) {
-            throw new ArithmeticException("Negative infinity: " + n);
+            n = 1;
         }
         int r = 0;
         while ((n >>= 1) > 0) {


### PR DESCRIPTION
Mth#log threw an exception when called, so I fixed it by making n default to 0